### PR TITLE
(feat) Add Facebok login support to Android

### DIFF
--- a/App/Containers/FBLoginView.js
+++ b/App/Containers/FBLoginView.js
@@ -65,7 +65,6 @@ class FBLoginView extends Component {
       <View>
         <LoginButton
           readPermissions={["public_profile","email","user_friends"]}
-          publishPermissions={[]}
           onLoginFinished={
             (error, result) => {
               if (error) {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-sdk
         android:minSdkVersion="18"
@@ -22,6 +21,7 @@
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
       <service android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService"/>
+      <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
       <meta-data
           android:name="com.google.android.geo.API_KEY"
           android:value="AIzaSyA7mzTLYqNFwA61p30fBmjgonIlsyogibI" />

--- a/android/app/src/main/java/com/sonder/MainActivity.java
+++ b/android/app/src/main/java/com/sonder/MainActivity.java
@@ -1,7 +1,9 @@
 package com.sonder;
 
+import android.content.Intent;
 import com.facebook.react.ReactActivity;
 import com.facebook.reactnative.androidsdk.FBSDKPackage;
+
 
 public class MainActivity extends ReactActivity {
 
@@ -13,4 +15,9 @@ public class MainActivity extends ReactActivity {
     protected String getMainComponentName() {
         return "Sonder";
     }
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+      super.onActivityResult(requestCode, resultCode, data);
+      MainApplication.getCallbackManager().onActivityResult(requestCode, resultCode, data);        
+    } 
 }

--- a/android/app/src/main/java/com/sonder/MainApplication.java
+++ b/android/app/src/main/java/com/sonder/MainApplication.java
@@ -21,7 +21,18 @@ import java.util.List;
 
 import com.joshblour.reactnativeheading.ReactNativeHeadingPackage;
 
+import com.facebook.CallbackManager;
+import com.facebook.FacebookSdk;
+import com.facebook.reactnative.androidsdk.FBSDKPackage;
+import com.facebook.appevents.AppEventsLogger;
+
+
 public class MainApplication extends Application implements ReactApplication {
+  private static CallbackManager mCallbackManager = CallbackManager.Factory.create();
+
+  protected static CallbackManager getCallbackManager() {
+    return mCallbackManager;
+  }
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -39,7 +50,8 @@ public class MainApplication extends Application implements ReactApplication {
             new ReactNativeI18n(),
             new RNDeviceInfo(),
             new ReactNativeConfigPackage(),
-            new ReactNativeHeadingPackage()
+            new ReactNativeHeadingPackage(),
+            new FBSDKPackage(mCallbackManager)
       );
     }
   };
@@ -52,6 +64,8 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    FacebookSdk.sdkInitialize(getApplicationContext());
+    AppEventsLogger.activateApp(this);
     SoLoader.init(this, /* native exopackage */ false);
   }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
 
     <string name="app_name">Sonder</string>
+    <string name="facebook_app_id">1809329449314574</string>
 </resources>


### PR DESCRIPTION
Also removed "readPermissions" from FBLogin component in order to prevent an error, as per the following note: "Note, that if read permissions are specified, then publish permissions should not be specified." at https://developers.facebook.com/docs/reference/ios/3.2.1/class/FBLoginView/